### PR TITLE
Changed name for mapping

### DIFF
--- a/std-2/5_AttendanceRegister/AttendanceRegister.sol
+++ b/std-2/5_AttendanceRegister/AttendanceRegister.sol
@@ -15,7 +15,7 @@ contract AttendanceRegister {
 
     event Added(string name, uint class, uint time);
 
-    mapping(uint => Student) public register; // roll number => student details
+    mapping(uint => Student) public registered; // roll number => student details
 
     modifier isTeacher {
         require(msg.sender == teacher, "Only teacher can add student");

--- a/std-2/5_AttendanceRegister/AttendanceRegister.sol
+++ b/std-2/5_AttendanceRegister/AttendanceRegister.sol
@@ -40,7 +40,7 @@ contract AttendanceRegister {
         require(class > 0 && class <= 12, "Invalid class");
         Student memory s = Student(name, class, joiningDate);
         rollNumber++;
-        register[rollNumber] = s;
+        registered[rollNumber] = s;
         emit Added(name, class, block.timestamp);
     }
 }


### PR DESCRIPTION
The name register for the mapping might not be the most descriptive, I changed it to registered because it makes more sense.